### PR TITLE
chore: Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,13 +83,11 @@ psd
 thumb
 sketch
 
+### IntelliJ ###
+.idea/
+
 ### VisualStudioCode ###
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
+.vscode/
 
 # Local History for Visual Studio Code
 .history/


### PR DESCRIPTION
We do not want to exclude files such as `/.vscode/settings.json`, ... from being ignored. They should also be ignored. The same applies to the folders themselves.